### PR TITLE
Add nightly db backup to midpoint role

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An ansible playbook for MariaDB on CentOS 7
 
+This playbook is idempotent and is safe to run against running systems.
+
 ## Roles
 
 * `database` - a standalone MariaDB server
@@ -40,7 +42,10 @@ mariadb:
   datadir: /data/mysql
   innodb_buffer_pool_size: changeme
   max_allowed_packet: changeme
+  backupsdir: /data/backups
 ```
+
+* `backupsdir` - dir for database backup dumpfiles. **NOTE:** backups are configured on a per-role basis. The `midpoint` role is an example of how this can be done.
 
 ### Configuring a midPoint Database
 

--- a/group_vars/example-dist
+++ b/group_vars/example-dist
@@ -3,6 +3,7 @@ mariadb:
   datadir: /data/mysql
   innodb_buffer_pool_size: changeme
   max_allowed_packet: changeme
+  backupsdir: /data/backups
 midpoint:
   midpoint_host: %.changeme.com
   db_name: changeme

--- a/roles/database/tasks/post_install.yml
+++ b/roles/database/tasks/post_install.yml
@@ -11,3 +11,10 @@
     permanent: true
     state: enabled
   with_items: [ '3306/tcp' ]
+
+- name: create dir for backups
+  file:
+    path: "{{ mariadb.backupsdir }}"
+    state: directory
+    owner: mysql
+    group: mysql

--- a/roles/midpoint/tasks/main.yml
+++ b/roles/midpoint/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
 - import_tasks: setup_db.yml
+- import_tasks: setup_backups.yml

--- a/roles/midpoint/tasks/setup_backups.yml
+++ b/roles/midpoint/tasks/setup_backups.yml
@@ -1,0 +1,18 @@
+---
+- name: create backup script dir
+  file:
+    path: /opt/mariadb
+    state: directory
+
+- name: copy over backup script from template
+  template:
+    src: backup-mariadb.sh.j2
+    dest: /opt/mariadb/backup-mariadb.sh
+    mode: 0700
+
+- name: create cron job
+  cron:
+    name: "backup db"
+    minute: "0"
+    hour: "2"
+    job: "/opt/mariadb/backup-mariadb.sh"

--- a/roles/midpoint/templates/backup-mariadb.sh.j2
+++ b/roles/midpoint/templates/backup-mariadb.sh.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mysqldump --single-transaction --quick --add-locks {{ midpoint.db_name }} | gzip > {{ mariadb.backupsdir }}/{{ midpoint.db_name }}-backup-`date +%Y-%m-%d`.gz
+
+find {{ mariadb.backupsdir }}/ -mtime +3 -exec rm -f {} \;


### PR DESCRIPTION
Also added a backupsdir variable for use by the database role,
which will ensure that the dir exists. The backupsdir is used to
store whatever database dumps are generated by backup jobs.

Backups should be configured on a per-role basis, as each
application/database ostensibly has its own backup requirements.